### PR TITLE
Config/logback gelf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM java:8-jre
 
 RUN	wget -q -O - https://github.com/kairosdb/kairosdb/releases/download/v1.2.1/kairosdb-1.2.1-1.tar.gz | tar xz -C /opt
+RUN wget -qO- https://github.com/Schemiii/logback-gelf/archive/v1.1.0-compiled.tar.gz | tar xvz --strip-components=2 -C /opt/kairosdb/lib/ logback-gelf-1.1.0-compiled/rel/logback-gelf-1.1.0.jar
 COPY	kairosdb.docker.sh /opt/kairosdb/bin/kairosdb.docker.sh
 COPY	kairosdb.logback.xml /opt/kairosdb/conf/logging/logback.xml
 

--- a/kairosdb.docker.sh
+++ b/kairosdb.docker.sh
@@ -18,5 +18,9 @@ if [ -n "$CASSANDRA_HOST_LIST" ]; then
 	conf kairosdb.datastore.cassandra.write_buffer_max_size 3000
 	conf kairosdb.datastore.cassandra.cql_host_list "$CASSANDRA_HOST_LIST"
 fi
+# Overwrite logback.xml file with custom configuration 
+if [ -n "$LOGBACK_CUSTOM" ]; then
+  echo $LOGBACK_CUSTOM > /opt/kairosdb/conf/logging/logback-test.xml && cat /opt/kairosdb/conf/logging/logback-test.xml 
+fi
 cat $CONF
 exec /opt/kairosdb/bin/kairosdb.sh run


### PR DESCRIPTION
This MR 
- adds logback-gelf jar (logback-gelf-1.1.0.jar)  to kairos image (opt/kairosdb/lib/)
- if env LOGBACK_CUSTOM is set creates a file - lockbag-test.xml in /opt/kairosdb/conf/logging - which contains content of LOGBACK_CUSTOM env variable.
=> This can be used to e.g. to run a kairosdb container which directly logs to graylog